### PR TITLE
terraform resources to manage dns records

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,16 @@
+/**
+https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set#binding-a-dns-name-to-the-ephemeral-ip-of-a-new-instance
+**/
+resource "google_dns_record_set" "webapp" {
+  name = var.dns_webapp_record_name
+  type = var.dns_webapp_record_type
+  ttl  = var.dns_webapp_record_ttl
+
+  managed_zone = data.google_dns_managed_zone.public-zone.name
+
+  rrdatas = [google_compute_instance.app_instance.network_interface[0].access_config[0].nat_ip]
+}
+
+data "google_dns_managed_zone" "public-zone" {
+  name = var.dns_managed_zone_name
+}

--- a/dns.variables.tf
+++ b/dns.variables.tf
@@ -1,0 +1,19 @@
+variable "dns_webapp_record_name" {
+    type = string
+    description = "The DNS name this record set will apply to."
+}
+
+variable "dns_webapp_record_type" {
+  type = string
+  description = "The DNS record set type"
+}
+
+variable "dns_webapp_record_ttl" {
+  type = number
+  description = "The time-to-live of this record set (seconds)."
+}
+
+variable "dns_managed_zone_name" {
+  type = string
+  description = "A unique name for the resource."
+}

--- a/firewalls.tf
+++ b/firewalls.tf
@@ -1,8 +1,8 @@
 # Add firewall rules to allow traffic to your application's port and deny SSH access from the internet.
 
 resource "google_compute_firewall" "allow_app_traffic" {
-  name    = "${var.vpc_name}-allow-app-traffic"
-  network = google_compute_network.vpc.self_link
+  name     = "${var.vpc_name}-allow-app-traffic"
+  network  = google_compute_network.vpc.self_link
   priority = var.allow_app_traffic_priority
 
   allow {
@@ -37,7 +37,7 @@ resource "google_compute_firewall" "deny_all_tcp" {
   }
 
   // currently 0.0.0.0/0 implies all IPv4 addresses
-  source_ranges = var.source_ranges_internet 
+  source_ranges = var.source_ranges_internet
 }
 
 resource "google_compute_firewall" "deny_all_udp" {
@@ -50,5 +50,5 @@ resource "google_compute_firewall" "deny_all_udp" {
   }
 
   // currently 0.0.0.0/0 implies all IPv4 addresses
-  source_ranges = var.source_ranges_internet 
+  source_ranges = var.source_ranges_internet
 }

--- a/firewalls.variables.tf
+++ b/firewalls.variables.tf
@@ -19,15 +19,15 @@ variable "ssh_ports" {
 }
 
 variable "all_ports" {
-  type = list(string)
+  type        = list(string)
   description = "Mention all ports"
-  default = [ "all" ]
+  default     = ["all"]
 }
 
 variable "source_ranges_internet" {
   type        = list(string)
   description = "CIDR source range for requests coming in from the internet"
-  default = [ "0.0.0.0/0" ]
+  default     = ["0.0.0.0/0"]
 }
 
 variable "allow_internet" {
@@ -38,32 +38,32 @@ variable "allow_internet" {
 variable "direction_ingress" {
   type        = string
   description = "For firewalls incoming rules"
-  default = "INGRESS"
+  default     = "INGRESS"
 }
 
 variable "allow_app_traffic_priority" {
-  type = number
+  type        = number
   description = "This gives the priority value to this firewall rule"
 }
 
 variable "deny_ssh_priority" {
-  type = number
+  type        = number
   description = "This gives the priority value to this firewall rule"
 }
 
 variable "deny_all_priority" {
-  type = number
+  type        = number
   description = "This gives the priority value to this firewall rule"
 }
 
 variable "tcp_protocol" {
-  type = string
+  type        = string
   description = "Refers to the tcp protocol"
-  default = "tcp"
+  default     = "tcp"
 }
 
 variable "udp_protocol" {
-  type = string
+  type        = string
   description = "Refers to the udp protocol"
-  default = "udp"
+  default     = "udp"
 }


### PR DESCRIPTION
# Title
This is the first PR where we begin committing changes for assignment 6

## Description
As part of assignment 6, we begin introducing DNS servers, application logging and metrics. We will merge this PR at the end to main branch after grading of assignment 5. 

## Code changes:
Added a new module to the terraform project - dns module. 
Reference: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set#binding-a-dns-name-to-the-ephemeral-ip-of-a-new-instance

## Screenshots: 
We notice the A record being added automatically to the DNS
<img width="541" alt="image" src="https://github.com/cloud-assignments-org/tf-gcp-infra/assets/113069126/62cc676d-3a17-4c2f-b638-e4d2f7195cd3">

## Testing:

We tested the changes by first destroying the added  A record and then later bringing it back, 
```shell

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # google_dns_record_set.webapp will be destroyed
  - resource "google_dns_record_set" "webapp" {
      - id           = "projects/cloudwebapp-417213/managedZones/public-zone/rrsets/webapp.parthadhruv.com./A" -> null
      - managed_zone = "public-zone" -> null
      - name         = "webapp.parthadhruv.com." -> null
      - project      = "cloudwebapp-417213" -> null
      - rrdatas      = [
          - "35.231.113.220",
        ] -> null
      - ttl          = 300 -> null
      - type         = "A" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
```

<img width="427" alt="image" src="https://github.com/cloud-assignments-org/tf-gcp-infra/assets/113069126/6691a81f-82ec-4c0b-85c4-381067c3365e">


Applying it back
```shell
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_dns_record_set.webapp will be created
  + resource "google_dns_record_set" "webapp" {
      + id           = (known after apply)
      + managed_zone = "public-zone"
      + name         = "webapp.parthadhruv.com."
      + project      = "cloudwebapp-417213"
      + rrdatas      = [
          + "35.231.113.220",
        ]
      + ttl          = 300
      + type         = "A"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

However we notice an issue where we aren't able to access the service through the domain name when we bring it back up!!

What could this be due to ?

It started working after a while.Why ?
